### PR TITLE
Add SteelHacks to navbar

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -162,6 +162,25 @@ function Header({ title }) {
               </div>
             </Link>
           </li>
+          <li className="py-2 md:py-0">
+            <a
+              href="https://steelhacks.org/"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              <div className="group relative w-full text-center text-lg font-bold md:text-base">
+                SteelHacks
+                <svg
+                  className="svg-underline absolute bottom-0 left-1/2 mx-auto w-full opacity-0 group-hover:opacity-100 transform-gpu -translate-x-1/2 transition"
+                  viewBox="0 0 479 20"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path d="M2.5 11.4996C106.5 -17.5 411.5 37.9996 476 7.49968" />
+                </svg>
+              </div>
+            </a>
+          </li>
           <li>
             <Link to="/join">
               <motion.button


### PR DESCRIPTION
Adds SteelHacks link to navigation bar that opens https://steelhacks.org/ in a new tab.