### PR TITLE
Sponsors: tier & add-on card hover effects

### DIFF
--- a/src/pages/sponsors.js
+++ b/src/pages/sponsors.js
@@ -368,10 +368,10 @@ const SponsorPage = ({ data }) => {
                 <motion.div
                   key={t.tier}
                   variants={item}
-                  className={`relative flex flex-col rounded-2xl border p-6 shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl ${
+                  className={`relative flex flex-col rounded-2xl border p-6 shadow-md transition duration-200 hover:-translate-y-1 ${
                     t.featured
-                      ? "border-secondary-100 bg-primary text-white"
-                      : "border-slate-200 bg-white text-slate-900 hover:border-yellow-400"
+                      ? "border-secondary-100 bg-primary text-white hover:shadow-2xl hover:ring-4 hover:ring-secondary-100/60"
+                      : "border-slate-200 bg-white text-slate-900 hover:border-yellow-400 hover:shadow-xl"
                   }`}
                   style={t.featured ? { backgroundColor: "#243E8B" } : undefined}
                 >

--- a/src/pages/sponsors.js
+++ b/src/pages/sponsors.js
@@ -368,7 +368,7 @@ const SponsorPage = ({ data }) => {
                 <motion.div
                   key={t.tier}
                   variants={item}
-                  className={`relative flex flex-col rounded-2xl border p-6 shadow-md transition-transform hover:-translate-y-1 hover:shadow-xl ${
+                  className={`relative flex flex-col rounded-2xl border p-6 shadow-md transition duration-200 hover:-translate-y-1 hover:shadow-xl ${
                     t.featured
                       ? "border-secondary-100 bg-primary text-white"
                       : "border-slate-200 bg-white text-slate-900 hover:border-yellow-400"
@@ -441,7 +441,7 @@ const SponsorPage = ({ data }) => {
                 {addOns.map((addOn) => (
                   <div
                     key={addOn.name}
-                    className="flex flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-md"
+                    className="flex flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-md transition duration-200 hover:-translate-y-1 hover:border-yellow-400 hover:shadow-xl"
                   >
                     <div className="flex items-baseline justify-between gap-2">
                       <h4 className="text-lg font-bold text-slate-900">


### PR DESCRIPTION
Follow-up to #130/#131 — polishes the hover interactions on the Sponsorship Tiers section.

## Changes
- **Smooth tier hover** — tier cards used `transition-transform`, so `hover:shadow-xl`/border snapped instead of animating. Switched to a full `transition` (0.2s) so shadow, border, and lift animate together.
- **Add-on card hover** — the Social Media add-on cards had no hover state; they now get the same lift + shadow + yellow border on hover as the tier cards.
- **Grace Hopper (featured) hover** — the shared hover leaned on a slate→yellow border change, which is a no-op on the already-yellow featured card, so its hover read as flat. The featured tier now gets its own treatment: a yellow glow ring (`ring-secondary-100/60`) + `shadow-2xl`, so it lifts as clearly as the white cards in its own visual language.

## Testing
- Verified via local `gatsby develop`: all tier cards and add-on cards lift smoothly on hover; the Grace Hopper card shows a distinct yellow glow ring on hover. Confirmed the custom ring color generated (`--tw-ring-color: rgb(255 184 28 / 0.6)`) rather than being purged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)