### PR TITLE
fix(footer): wrap nav links on mobile instead of overflowing

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -3,9 +3,9 @@ import { Link } from "gatsby";
 
 function Footer() {
   return (
-    <footer className="container flex items-center justify-center mx-auto w-full h-32 text-center">
+    <footer className="container flex items-center justify-center mx-auto w-full py-8 text-center">
       <nav className="w-full space-y-2">
-        <ul className="flex items-center justify-center mx-auto font-bold gap-8">
+        <ul className="flex flex-wrap items-center justify-center mx-auto font-bold gap-x-8 gap-y-2 px-4 [&_li]:whitespace-nowrap">
           <Link to="/">
             <li>Home</li>
           </Link>


### PR DESCRIPTION
## Problem

On mobile the whole page could be scrolled left/right. The footer nav was a non-wrapping flex row (`flex ... gap-8`), so the six links overflowed the viewport and widened the document.

Measured at 375px before the fix:

| | value |
|---|---|
| viewport | 375px |
| footer `<ul>` scrollWidth | **432px** |
| document scrollWidth | **432px** |
| horizontally scrollable | **yes** |

The last link ("Join") ended at exactly 432px — the same as the document's scroll width, confirming the footer was the source. The header appearing 432px wide was a symptom of the widened document, not a second bug.

## Fix

- `flex-wrap` so the row wraps instead of overflowing, with `gap-y-2` for the wrapped row and `[&_li]:whitespace-nowrap` to keep each label on one line (previously "About Us" broke across two lines).
- `py-8` instead of a fixed `h-32`, so a wrapped second row isn't clipped.

## Verification

| width | rows | doc scrollWidth | scrollable | clipped |
|---|---|---|---|---|
| 375 (iPhone) | 2 | 375 | no | none |
| 430 (15 Pro Max) | 2 | 430 | no | none |
| desktop | 1 | — | no | none |

Desktop is unchanged: one row, links in original order.
