### PR TITLE
fix(meet): shared links said "Loading", plus selector cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ public
 .env
 .env.*
 !.env.example
+
+# Local Netlify folder
+.netlify

--- a/src/components/meet/AvailabilityGrid.js
+++ b/src/components/meet/AvailabilityGrid.js
@@ -121,11 +121,14 @@ export default function AvailabilityGrid({ view, states, onChange }) {
   }, [allSlots, slotsWhere]);
 
   const applyPreset = (preset) => {
-    // Additive: presets stack, so "Weekdays" then "Weekends" is everything.
-    const next = Uint8Array.from(states);
+    // Replaces rather than stacks. Stacking meant tapping Weekdays then Weekends left
+    // you with everything and no way back except Clear, so the buttons couldn't be used
+    // to compare options — which is the obvious thing to try. Replacing also matches
+    // how the date presets on the create screen already behave.
+    const next = new Uint8Array(states.length);
     for (const i of preset.slots) next[i] = AVAILABLE;
-    commit(next, preset.slots);
-    setAnnouncement(`${preset.label} added — ${preset.slots.length} half-hours selected`);
+    commit(next, allSlots);
+    setAnnouncement(`${preset.label} — ${preset.slots.length} half-hours selected`);
   };
 
   const clearAll = () => {

--- a/src/components/meet/CreateForm.js
+++ b/src/components/meet/CreateForm.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import MonthPicker from "./MonthPicker";
 import TimeRangeSlider from "./TimeRangeSlider";
@@ -73,9 +73,17 @@ export default function CreateForm({ onCreated }) {
   };
 
   const span = endMin - startMin;
+  const nameMissing = error === "Give the meeting a name.";
+
+  const nameRef = useRef(null);
 
   const submit = async (event) => {
     event.preventDefault();
+    if (!name.trim()) {
+      setError("Give the meeting a name.");
+      if (nameRef.current) nameRef.current.focus();
+      return;
+    }
     if (!dates.length) {
       setError("Pick at least one day.");
       return;
@@ -101,7 +109,7 @@ export default function CreateForm({ onCreated }) {
 
   return (
     <form onSubmit={submit} noValidate>
-      {error && (
+      {error && !nameMissing && (
         <p className="mb-6 px-4 py-3 text-red-800 text-sm bg-red-50 border border-red-200 rounded-xl">
           {error}
         </p>
@@ -109,15 +117,30 @@ export default function CreateForm({ onCreated }) {
 
       <Field label="What's the meeting?">
         <input
-          className="px-4 py-3 w-full text-lg font-bold border border-gray-300 rounded-xl focus:border-primary focus:ring-primary"
+          ref={nameRef}
+          id="meet-name"
+          className={`px-4 py-3 w-full text-lg font-bold border rounded-xl focus:border-primary focus:ring-primary ${
+            nameMissing ? "border-red-400" : "border-gray-300"
+          }`}
           placeholder="SteelHacks planning"
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => {
+            setName(e.target.value);
+            if (error) setError(null);
+          }}
           maxLength={90}
           autoFocus
+          required
           autoComplete="off"
           aria-label="Meeting name"
+          aria-invalid={nameMissing || undefined}
+          aria-describedby={nameMissing ? "meet-name-error" : undefined}
         />
+        {nameMissing && (
+          <p id="meet-name-error" className="mt-2 text-red-700 text-sm">
+            {error}
+          </p>
+        )}
       </Field>
 
       <Field label="What days could work?" hint="Select all that work.">
@@ -128,7 +151,6 @@ export default function CreateForm({ onCreated }) {
               {label}
             </Chip>
           ))}
-          {dates.length > 0 && <Chip onClick={() => setDates([])}>Clear</Chip>}
         </div>
       </Field>
 

--- a/src/components/meet/MonthPicker.js
+++ b/src/components/meet/MonthPicker.js
@@ -1,5 +1,4 @@
 import React, { useMemo, useRef, useState } from "react";
-import { summarizeDates } from "../../lib/meet/format";
 import { dayLabel, isoAddDays, isoOf, isoToday, isoWeekday, parseIso } from "../../lib/meet/time";
 
 const MONTHS = [
@@ -168,25 +167,32 @@ export default function MonthPicker({ value, onChange, tz }) {
         </button>
       </div>
 
-      {/* The written form of the selection, next to the thing that changes it. */}
-      <div className="flex flex-wrap items-baseline justify-center gap-x-2 mt-1 mb-2 text-sm">
-        {value.length ? (
-          <>
-            <span className="font-bold text-primary">{summarizeDates(value)}</span>
-            <span className="text-gray-400">
-              {value.length} {value.length === 1 ? "day" : "days"}
-            </span>
-          </>
-        ) : (
-          <span className="text-gray-400">No days selected</span>
+      {/* A count, not a list. The cells below already say *which* days, and they say it
+          better — adjacent selections visibly touch, scattered ones stand apart. A
+          compressed restatement like "Sep 15, Sep 16 +3" only asks the reader to decode
+          what they can already see. Grey, because this confirms rather than invites. */}
+      <div className="flex flex-wrap items-baseline justify-center gap-x-2 mt-1 mb-2 text-gray-500 text-sm">
+        <span>
+          {value.length
+            ? `${value.length} ${value.length === 1 ? "day" : "days"} selected`
+            : "No days selected"}
+        </span>
+        {value.length > 0 && (
+          <button
+            type="button"
+            className="px-2 py-1.5 -my-1 underline hover:text-gray-900"
+            onClick={() => onChange([])}
+          >
+            Clear
+          </button>
         )}
         {offscreen && (
           <button
             type="button"
-            className="px-2 py-1.5 -my-1 text-gray-500 underline hover:text-gray-900"
+            className="px-2 py-1.5 -my-1 underline hover:text-gray-900"
             onClick={() => setCursor(offscreen.jumpTo)}
           >
-            +{offscreen.count} in {offscreen.month}
+            {offscreen.count} not shown
           </button>
         )}
       </div>

--- a/src/lib/meet/client.js
+++ b/src/lib/meet/client.js
@@ -161,6 +161,18 @@ export function recentMeetings() {
   return (read(`${NS}.recent`) || []).slice(0, 6);
 }
 
+/**
+ * Forget a meeting locally. Deliberately local-only: the link still works and the other
+ * participants' answers are untouched — this is "take it off my list", not "delete it
+ * for everyone", which is not a call one participant should get to make.
+ */
+export function forgetMeeting(code) {
+  if (typeof window === "undefined") return [];
+  const next = recentMeetings().filter((m) => m.code !== code);
+  write(`${NS}.recent`, next);
+  return next;
+}
+
 export function rememberMeeting(entry) {
   if (typeof window === "undefined" || !entry || !entry.code) return;
   const existing = recentMeetings().filter((m) => m.code !== entry.code);

--- a/src/lib/meet/model.js
+++ b/src/lib/meet/model.js
@@ -160,8 +160,8 @@ function toSlotMinute(value, fallback) {
  * the API layer can stay a thin shell.
  */
 export function normalizeCreate(body) {
-  const name =
-    cleanString(body && body.name, LIMITS.meetingNameLen) || "Untitled meeting";
+  const name = cleanString(body && body.name, LIMITS.meetingNameLen);
+  if (!name) fail("Give the meeting a name.");
 
   const rawDates = Array.isArray(body && body.dates) ? body.dates : [];
   const dates = Array.from(new Set(rawDates.filter((d) => parseIso(d)))).sort();

--- a/src/pages/meet/[code].js
+++ b/src/pages/meet/[code].js
@@ -3,6 +3,7 @@ import { Link } from "gatsby";
 import { motion } from "framer-motion";
 
 import Layout from "../../layouts/layout";
+import Seo from "../../components/seo";
 import ShareBar from "../../components/meet/ShareBar";
 import AvailabilityGrid from "../../components/meet/AvailabilityGrid";
 import GroupGrid from "../../components/meet/GroupGrid";
@@ -43,6 +44,9 @@ const POLL_MS = 15000;
 
 const CALLOUT =
   "px-4 py-3 text-sm bg-secondary-200 border border-secondary-100 rounded-2xl";
+
+/** What a shared link says before React knows which meeting it is. */
+const SHARE_TITLE = "Add your availability | Computer Science Club @ Pitt";
 
 const PRIMARY_BTN =
   "px-5 py-2.5 text-white font-bold bg-primary rounded-full focus:outline-none hover:shadow-lg shadow-md transition";
@@ -248,7 +252,7 @@ export default function MeetRoom({ params, location }) {
 
   if (loadError) {
     return (
-      <Shell title="Meeting not found | Computer Science Club @ Pitt">
+      <Shell title={SHARE_TITLE}>
         <h1 className="mb-3 text-3xl font-bold">That link didn&apos;t work</h1>
         <p className="mb-6 text-gray-500">{loadError}</p>
         <Link className={PRIMARY_BTN} to="/meet">
@@ -260,7 +264,7 @@ export default function MeetRoom({ params, location }) {
 
   if (!meeting || !view || !group) {
     return (
-      <Shell title="Loading | Computer Science Club @ Pitt" wide>
+      <Shell title={SHARE_TITLE} wide>
         <div className="meet-skeleton h-10 w-64" />
         <div className="meet-skeleton h-14 mt-5" />
         <div className="meet-skeleton h-96 mt-5" />
@@ -513,9 +517,20 @@ export default function MeetRoom({ params, location }) {
 
 /* --------------------------------- pieces --------------------------------- */
 
+/**
+ * `title` is what a browser tab shows once React has the meeting. It is *not* what a
+ * link unfurler sees: this is a client-only route, so Slack, iMessage and friends only
+ * ever get the pre-hydration HTML. That HTML previously carried the loading state, so
+ * every shared meeting link unfurled as "Loading" — on the one screen whose entire job
+ * is to be shared. Hence the meet-specific defaults.
+ */
 function Shell({ title, wide, children }) {
   return (
     <Layout title={title}>
+      <Seo
+        title={title}
+        description="Someone shared a meeting with you. Add the times you're free and the best slot for everyone appears automatically."
+      />
       <motion.div
         className="meet overflow-hidden"
         initial={{ opacity: 0 }}

--- a/src/pages/meet/index.js
+++ b/src/pages/meet/index.js
@@ -4,7 +4,12 @@ import { motion } from "framer-motion";
 
 import Layout from "../../layouts/layout";
 import CreateForm from "../../components/meet/CreateForm";
-import { fetchHealth, recentMeetings, rememberMeeting } from "../../lib/meet/client";
+import {
+  fetchHealth,
+  forgetMeeting,
+  recentMeetings,
+  rememberMeeting,
+} from "../../lib/meet/client";
 
 export default function MeetHome() {
   const [recent, setRecent] = useState([]);
@@ -79,21 +84,34 @@ export default function MeetHome() {
                   </h2>
                   <ul className="space-y-2">
                     {recent.map((entry) => (
-                      <li key={entry.code}>
+                      <li
+                        key={entry.code}
+                        className="flex items-stretch gap-2 bg-white border border-gray-200 rounded-2xl hover:border-gray-400 transition"
+                      >
                         <Link
                           to={`/meet/${entry.code}`}
-                          className="flex items-center justify-between px-4 py-3 bg-white border border-gray-200 rounded-2xl hover:border-gray-400 transition"
+                          className="flex flex-1 items-center justify-between min-w-0 px-4 py-3"
                         >
-                          <span className="font-bold truncate">
-                            {entry.name || "Untitled meeting"}
-                          </span>
+                          <span className="font-bold truncate">{entry.name}</span>
                           <span className="flex-none ml-3 text-gray-400 text-sm">
                             /meet/{entry.code}
                           </span>
                         </Link>
+                        <button
+                          type="button"
+                          onClick={() => setRecent(forgetMeeting(entry.code))}
+                          aria-label={`Remove ${entry.name} from this list`}
+                          title="Remove from this list. The meeting itself is unaffected."
+                          className="flex-none px-3 text-gray-300 text-xl leading-none hover:text-red-600 focus:text-red-600 transition"
+                        >
+                          &times;
+                        </button>
                       </li>
                     ))}
                   </ul>
+                  <p className="mt-2 text-gray-400 text-xs">
+                    Removing only clears it from this device. The link keeps working.
+                  </p>
                 </div>
               )}
             </div>

--- a/src/styles/components/_meet.scss
+++ b/src/styles/components/_meet.scss
@@ -195,9 +195,24 @@
   background-color: var(--meet-primary);
 }
 
-/* A run of selected cells should read as one block, not a stripe of separate ones. */
-.meet-cell[data-state="2"] + .meet-cell[data-state="2"] {
-  border-top-color: rgba(255, 255, 255, 0.22);
+/* Inside a selected run the separators have to be *regular*, or they read as noise.
+   The grid's own rules are a light hairline on half-hours and a darker one on the hour;
+   over a dark fill both show through at different strengths and in different places
+   depending on where the selection happens to start, which looks arbitrary. Give
+   selected cells their own consistent rhythm instead: a faint line every half hour, a
+   clearer one on the hour. (The old rule here targeted the adjacent *sibling*, which in
+   a row-major grid is the cell to the right — so it never affected the vertical runs it
+   claimed to.) */
+.meet-cell[data-state="2"] {
+  border-top-color: rgba(255, 255, 255, 0.16);
+}
+
+.meet-cell[data-state="2"][data-hour="true"] {
+  border-top-color: rgba(255, 255, 255, 0.42);
+}
+
+.meet-cell[data-state="2"][data-firstrow="true"] {
+  border-top: 0;
 }
 
 .meet-cell[data-anchor="true"]::after {

--- a/tests/meet/model.test.mjs
+++ b/tests/meet/model.test.mjs
@@ -8,7 +8,8 @@ import {
 } from "../../src/lib/meet/model.js";
 import { H, meeting } from "./helpers.mjs";
 
-const create = (o) => normalizeCreate({ dates: ["2026-09-02"], ...o });
+// A name is required, so the helper supplies one; tests that care override it.
+const create = (o) => normalizeCreate({ name: "Test", dates: ["2026-09-02"], ...o });
 
 test("the default state is unavailable, so silence is never a yes", () => {
   assert.equal(UNAVAILABLE, 0);
@@ -33,7 +34,16 @@ test("a window may not straddle a day boundary", () => {
 });
 
 test("creation rejects input the UI would never send", () => {
-  assert.throws(() => normalizeCreate({ dates: [] }), /at least one date/i);
+  assert.throws(() => create({ dates: [] }), /at least one date/i);
+  // A name is required: an untitled meeting is unidentifiable in a group chat, and
+  // silently substituting "Untitled meeting" hides the omission from whoever made it.
+  assert.throws(() => create({ name: "" }), /give the meeting a name/i);
+  assert.throws(() => create({ name: "   " }), /give the meeting a name/i);
+  assert.throws(
+    () => normalizeCreate({ dates: ["2026-09-02"] }),
+    /give the meeting a name/i,
+    "omitted entirely, not just blank"
+  );
   assert.throws(() => create({ startMin: H(20), endMin: H(10) }), /end time/i);
   assert.throws(() => create({ startMin: H(10), endMin: H(10) }), /end time/i);
   // Genuinely distinct consecutive days, or dedup would quietly bring it under.
@@ -41,14 +51,14 @@ test("creation rejects input the UI would never send", () => {
     new Date(Date.UTC(2026, 8, 1 + i)).toISOString().slice(0, 10)
   );
   assert.equal(new Set(tooMany).size, LIMITS.dates + 5, "fixture really is over the cap");
-  assert.throws(() => normalizeCreate({ dates: tooMany }), /days or fewer/i);
-  assert.throws(() => normalizeCreate({ dates: ["2026-01-01", "2028-01-01"] }), /within a year/i);
+  assert.throws(() => create({ dates: tooMany }), /days or fewer/i);
+  assert.throws(() => create({ dates: ["2026-01-01", "2028-01-01"] }), /within a year/i);
 });
 
 test("creation is forgiving about things it can safely normalise", () => {
   const m = create({ dates: ["2026-09-04", "2026-09-02", "2026-09-02", "not-a-date"] });
   assert.deepEqual(m.dates, ["2026-09-02", "2026-09-04"], "sorted, deduped, junk dropped");
-  assert.equal(create({ name: "" }).name, "Untitled meeting");
+  assert.equal(create({ name: "  Retro  " }).name, "Retro", "trimmed, not rejected");
   assert.equal(create({ tz: "Mars/Olympus" }).tz, "America/New_York", "unknown zone falls back");
   assert.equal(create({ startMin: 61, endMin: 1000 }).startMin, 60, "times snap to the slot grid");
 });


### PR DESCRIPTION
Follow-ups to #138, all from looking at the shipped thing.

## Shared links unfurled as "Loading"

`/meet/:code` is a client-only route, so Slack, iMessage and friends only ever see the
pre-hydration HTML — which carried the loading state. Every meeting link anyone pasted
anywhere previewed as **"Loading | Computer Science Club @ Pitt"** with the generic
site description, on the one screen whose entire purpose is to be shared.

It now reads *"Add your availability"* with a description about the meeting, verified
in the built HTML.

The meeting's own name still can't appear in the preview — the code isn't known at
build time. Rendering it would mean converting the route to SSR via `getServerData`,
which is a real option but a bigger change than this fix deserved.

## A meeting name is now required

It used to silently become "Untitled meeting". That's unidentifiable in the group chat
it gets pasted into, and the substitution hid the omission from the person who made it.
Validated on both the client and the API, with the message shown at the field rather
than at the top of the form.

## Date summary

`Sep 15, Sep 16 +3` asked the reader to decode a compressed list of something the
calendar already communicates better — adjacent days visibly touch, scattered ones
stand apart. Now just `5 days selected`, in grey because it confirms rather than
invites.

`Clear` moves out of the preset row, where it wrapped onto its own line and read as a
fifth preset, and now sits beside the count it acts on.

## Availability presets replace instead of stacking

Tapping **Weekdays** then **Weekends** left you with both and no route back except
Clear, so the buttons couldn't be used to compare options — the obvious thing to try.
They now switch, matching how the date presets already behaved. Verified: Weekdays 120
slots → Weekends 48 (not 168) → Weekdays 120 again.

## Grid separators looked random

Inside a selected run those lines were the grid's own hairlines showing through a dark
fill at two different strengths, landing in different places depending on where the
selection started. Selected cells now have their own rhythm — faint on the half hour,
clearer on the hour.

The rule that claimed to handle this targeted the adjacent *sibling*, which in a
row-major grid is the cell to the right, so it never affected the vertical runs it was
written for.

## Also

A small **×** on each entry in Recent removes it from that list. Local only — the link
keeps working and other participants' answers are untouched, which isn't a call one
participant should get to make.

---

`npm test` — 75 tests, green. `gatsby build` passes. Every change above was checked in
a browser, not just in the diff.
