### PR TITLE
fix(qr): transparent background on exported codes

### DIFF
--- a/src/pages/qr.js
+++ b/src/pages/qr.js
@@ -25,7 +25,10 @@ const baseOptions = {
   dotsOptions: squareNavy,
   cornersSquareOptions: squareNavy,
   cornersDotOptions: squareNavy,
-  backgroundOptions: { color: "#ffffff" },
+  // Fully transparent, so an exported code drops onto a slide or poster of any
+  // colour without a white card around it. rgba rather than the keyword because it
+  // is unambiguous in both the canvas preview and the SVG export.
+  backgroundOptions: { color: "rgba(0,0,0,0)" },
   imageOptions: {
     margin: 0,
     hideBackgroundDots: true,
@@ -136,15 +139,23 @@ const QrPage = () => {
             </div>
 
             <p className="mt-6 text-sm text-gray-500">
-              Tip: PNG is best for slides and social posts, SVG for print.
-              Always verify the final code with your phone.
+              Both export with a transparent background, so they sit on any colour.
+              The code is dark navy, so keep it on a light backdrop or it
+              won&rsquo;t scan. Always check the final code with your phone.
             </p>
           </div>
 
           {/* Live preview */}
           <div className="flex flex-col items-center">
             <div
-              className="w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 bg-white p-4 shadow-md"
+              className="w-full max-w-sm overflow-hidden rounded-2xl border border-gray-200 p-4 shadow-md"
+              style={{
+                // Checkerboard, not white: the code is transparent now, and against
+                // a white card that would look identical to the old behaviour.
+                backgroundImage:
+                  "repeating-conic-gradient(#eef0f4 0% 25%, #ffffff 0% 50%)",
+                backgroundSize: "16px 16px",
+              }}
               aria-label="QR code preview"
             >
               <div ref={previewRef} className="[&>canvas]:h-auto [&>canvas]:w-full" />


### PR DESCRIPTION
`/qr` baked a solid white background into every code, so a downloaded PNG or SVG
carried a white card with it and could only be placed on white. Both export formats
support alpha and neither is JPEG, so nothing is traded away.

The preview card swaps its white fill for a checkerboard — against a white card a
transparent code looks exactly like the old one, so the change would otherwise be
invisible in the one place you'd check it.

Verified at the pixel level, not just in the diff: the exported canvas' corner pixel
reads `[0, 0, 0, 0]`.

### Two things worth knowing

**The centre logo stays opaque.** `src/images/qr-logo.png` is a palette PNG with no
alpha channel, so it still renders as a solid block in the middle. I did not touch it:
pure white makes up 32% of the image and ~7,300 of those pixels sit *inside* the
artwork (the laptop screen), so keying white out would punch holes through the logo
rather than just clearing its background. Fixing this properly needs a logo exported
with a real alpha channel — happy to swap it in if you have one.

**A transparent code needs a light backdrop.** Transparency removes the guaranteed
white quiet zone a scanner relies on for contrast. The dots are dark navy, so the code
scans on light backgrounds and fails on dark ones. The on-page tip now says so.