### PR TITLE
fix(meet): a preset no longer makes calendar import a no-op

### DIFF
--- a/src/components/meet/AvailabilityGrid.js
+++ b/src/components/meet/AvailabilityGrid.js
@@ -63,19 +63,19 @@ export default function AvailabilityGrid({ view, states, onChange }) {
   }, [shown]);
 
   const commit = useCallback(
-    (next, indices) => {
-      onChange(next, indices);
+    (next, indices, options) => {
+      onChange(next, indices, options);
       setDraft(null);
     },
     [onChange]
   );
 
   const paintMany = useCallback(
-    (indices, value) => {
+    (indices, value, options) => {
       if (!indices.length) return;
       const next = Uint8Array.from(states);
       for (const i of indices) next[i] = value;
-      commit(next, indices);
+      commit(next, indices, options);
     },
     [commit, states]
   );
@@ -127,12 +127,12 @@ export default function AvailabilityGrid({ view, states, onChange }) {
     // how the date presets on the create screen already behave.
     const next = new Uint8Array(states.length);
     for (const i of preset.slots) next[i] = AVAILABLE;
-    commit(next, allSlots);
+    commit(next, allSlots, { replacesAll: true });
     setAnnouncement(`${preset.label} — ${preset.slots.length} half-hours selected`);
   };
 
   const clearAll = () => {
-    paintMany(allSlots, UNAVAILABLE);
+    paintMany(allSlots, UNAVAILABLE, { replacesAll: true });
     setAnnouncement("Cleared");
   };
 

--- a/src/lib/meet/calendar.js
+++ b/src/lib/meet/calendar.js
@@ -46,6 +46,25 @@ export function applyBusyIntervals(slots, intervals, { previous, manual } = {}) 
   return next;
 }
 
+/**
+ * Record which slots were edited by hand, for the "manual edits win" rule above.
+ *
+ * A preset or Clear rewrites the whole grid in one tap, so the edit covers every slot —
+ * but none of those is a considered per-slot decision, and banking them as such made a
+ * later import a silent no-op: it computed the calendar's answer and then restored the
+ * preset over all of it, so uploading a .ics appeared to do nothing. Whole-grid
+ * replacements reset the record instead of filling it; a preset is a starting point an
+ * import is allowed to refine, while a cell you actually painted still wins.
+ */
+export function trackManualEdits(manual, indices, { replacesAll = false } = {}) {
+  if (replacesAll) {
+    manual.clear();
+    return manual;
+  }
+  for (const i of indices || []) manual.add(i);
+  return manual;
+}
+
 /* ----------------------------------- ICS ----------------------------------- */
 
 /**

--- a/src/pages/meet/[code].js
+++ b/src/pages/meet/[code].js
@@ -36,6 +36,7 @@ import {
   rankWindows,
   topBlockers,
 } from "../../lib/meet/score";
+import { trackManualEdits } from "../../lib/meet/calendar";
 import { describeWindow, nameList, summarizeDates } from "../../lib/meet/format";
 import { durationLabel, localTz, rangeLabel, tzCity } from "../../lib/meet/time";
 
@@ -227,9 +228,9 @@ export default function MeetRoom({ params, location }) {
   }, [flush]);
 
   const onGridChange = useCallback(
-    (next, indices) => {
+    (next, indices, options) => {
       setMySlots(next);
-      if (indices) for (const i of indices) manualEdits.current.add(i);
+      trackManualEdits(manualEdits.current, indices, options);
       setSource("manual");
       scheduleSave(next);
     },

--- a/tests/meet/calendar.test.mjs
+++ b/tests/meet/calendar.test.mjs
@@ -1,7 +1,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { applyBusyIntervals, mergeIntervals, parseIcs } from "../../src/lib/meet/calendar.js";
+import {
+  applyBusyIntervals,
+  mergeIntervals,
+  parseIcs,
+  trackManualEdits,
+} from "../../src/lib/meet/calendar.js";
 import { AVAILABLE, UNAVAILABLE, enumerateSlots, slotsPerDay } from "../../src/lib/meet/model.js";
 import { H, meeting } from "./helpers.mjs";
 
@@ -153,6 +158,47 @@ test("folded lines, DURATION and UTC stamps all parse", () => {
   assert.equal(intervals.length, 2);
   // 6:00-7:30pm from DURATION, and 8-9pm from the UTC-form event.
   assert.equal(row(m, applyBusyIntervals(w.slots, intervals), 0), "####...#..##");
+});
+
+test("a preset does not turn a later import into a no-op", () => {
+  // Jayson's report: tap Anytime, upload a .ics, and the whole grid stays selected even
+  // though the banner says it found busy blocks. The preset had banked every slot as a
+  // hand edit, so the import computed the right answer and then threw all of it away.
+  const m = meeting({ dates: ["2026-09-02", "2026-09-03"] });
+  const w = window(m);
+  const all = w.slots.map((s) => s.index);
+
+  const previous = new Uint8Array(w.slots.length).fill(AVAILABLE); // what Anytime paints
+  const manual = trackManualEdits(new Set(), all, { replacesAll: true });
+  assert.equal(manual.size, 0, "a whole-grid replacement is not a per-slot decision");
+
+  const intervals = parseIcs(
+    ics(
+      ...vevent(
+        "DTSTART;TZID=America/New_York:20260902T180000",
+        "DTEND;TZID=America/New_York:20260902T200000",
+        "RRULE:FREQ=WEEKLY;BYDAY=WE,TH;UNTIL=20261211T235959Z"
+      )
+    ),
+    w
+  );
+  const states = applyBusyIntervals(w.slots, intervals, { previous, manual });
+  assert.equal(row(m, states, 0), "####....####", "Wed 6-8pm comes out of the selection");
+  assert.equal(row(m, states, 1), "####....####", "and so does Thu");
+});
+
+test("a hand-painted cell still wins over an import", () => {
+  const m = meeting({ dates: ["2026-09-02"] });
+  const w = window(m);
+  // Anytime, then one deliberate correction: 4:00 deselected by hand.
+  const manual = trackManualEdits(new Set(), w.slots.map((s) => s.index), { replacesAll: true });
+  trackManualEdits(manual, [0]);
+  assert.deepEqual([...manual], [0], "only the cell the person actually touched is kept");
+
+  const previous = new Uint8Array(w.slots.length).fill(AVAILABLE);
+  previous[0] = UNAVAILABLE;
+  const states = applyBusyIntervals(w.slots, [], { previous, manual });
+  assert.equal(row(m, states, 0), ".###########");
 });
 
 test("manual edits survive a re-import", () => {


### PR DESCRIPTION
Reported by Jayson: upload a `.ics` and the grid stays fully selected, even though the banner says it found busy blocks. His 17-day poll sat at the full 136 hours after importing.

Not the `.ics` parser — his file parsed correctly. Presets and the import fight over the same record, and the preset wins.

## Root cause

Every grid edit goes through `commit(next, indices)` → `onGridChange`, which banks each index in `manualEdits`. `applyPreset` called `commit(next, allSlots)` — every slot in the grid. So one tap on **Anytime / Weekdays / Weekends / Evenings / Clear** marked the entire grid as hand-edited.

`applyBusyIntervals` then does exactly what it documents — manual edits win:

```js
if (manual.has(i)) next[i] = previous[i];
```

With every index in `manual`, the import computed the right answer and then restored the preset over all of it. The banner still reports what it found, which is why this reads as a parser failure.

## Reproduced both directions

Same `.ics` (weekly Wed/Thu 6–8pm class), same dev server, same click path — tap Anytime, then upload:

| | after preset | after import |
|---|---|---|
| before | 24 hours | **24 hours** — unchanged |
| after | 24 hours | **20 hours** |

Banner identical in both runs: *"…around 2 busy blocks across 2 days (~4h)."*

## Fix

`trackManualEdits(manual, indices, { replacesAll })`, added to `calendar.js` next to the rule that honours it. A whole-grid replacement resets the record instead of filling it — a preset is a starting point an import is allowed to refine — while a cell you actually painted still wins, which is the case that rule existed for.

Presets and Clear pass `replacesAll: true`. Drags, day toggles and row toggles are unchanged and still protected.

## Tests

Two regression tests in `tests/meet/calendar.test.mjs`:

- a preset does not turn a later import into a no-op
- a hand-painted cell still wins over an import

77/77 pass, including the 16 API integration tests.