### PR TITLE
fix(meet): a timed event marked "Free" still counts as busy

### DIFF
--- a/src/lib/meet/calendar.js
+++ b/src/lib/meet/calendar.js
@@ -211,8 +211,17 @@ const BYDAY = { SU: 0, MO: 1, TU: 2, WE: 3, TH: 4, FR: 5, SA: 6 };
 
 function expandEvent(event, out, windowStartMs, windowEndMs) {
   if (!event.start || !event.start.ms) return;
-  // Declined and free-marked events aren't conflicts.
-  if (event.status === "CANCELLED" || event.transparent) return;
+  if (event.status === "CANCELLED") return;
+  // A free-marked *all-day* event is a label rather than a commitment — a trip name,
+  // a "midterms week" banner — and treating one as busy would wipe the whole day.
+  //
+  // A timed event marked free is a different animal. University course feeds ship
+  // every class as TRANSP:TRANSPARENT, so honouring the flag there drops the entire
+  // schedule and leaves the person looking wide open on the exact hours they are in
+  // class — the one failure this tool cannot have. A timed event counts as busy
+  // whatever its transparency says; the import banner invites you to adjust anything
+  // that's off, and over-claiming a conflict is the recoverable direction.
+  if (event.transparent && event.start.allDay) return;
 
   const startMs = event.start.ms;
   let durationMs = event.durationMs;

--- a/tests/meet/calendar.test.mjs
+++ b/tests/meet/calendar.test.mjs
@@ -77,18 +77,56 @@ test("a weekly class expands onto the right days only", () => {
   assert.equal(row(m, s, 3), "############", "Sat is not");
 });
 
-test("cancelled and free-marked events are not conflicts", () => {
+test("a cancelled event is not a conflict", () => {
   const m = meeting({ dates: ["2026-09-02"] });
   const w = window(m);
   const intervals = parseIcs(
     ics(
-      ...vevent("DTSTART;TZID=America/New_York:20260902T170000", "DTEND;TZID=America/New_York:20260902T220000", "STATUS:CANCELLED"),
-      ...vevent("DTSTART;TZID=America/New_York:20260902T170000", "DTEND;TZID=America/New_York:20260902T220000", "TRANSP:TRANSPARENT")
+      ...vevent(
+        "DTSTART;TZID=America/New_York:20260902T170000",
+        "DTEND;TZID=America/New_York:20260902T220000",
+        "STATUS:CANCELLED"
+      )
     ),
     w
   );
   assert.equal(intervals.length, 0);
   assert.equal(row(m, applyBusyIntervals(w.slots, intervals), 0), "############");
+});
+
+test("an all-day event marked free is a label, not a conflict", () => {
+  // "Acadia", "midterms week" — blocking on one of these would wipe the whole day.
+  const m = meeting({ dates: ["2026-09-02"] });
+  const w = window(m);
+  const intervals = parseIcs(
+    ics(...vevent("DTSTART;VALUE=DATE:20260902", "DTEND;VALUE=DATE:20260903", "TRANSP:TRANSPARENT")),
+    w
+  );
+  assert.equal(intervals.length, 0);
+  assert.equal(row(m, applyBusyIntervals(w.slots, intervals), 0), "############");
+});
+
+test("a timed event marked free still counts as busy", () => {
+  // Jayson's report: Pitt's course feed ships every class as TRANSP:TRANSPARENT, so
+  // honouring the flag dropped his whole schedule and left him looking wide open on
+  // the exact hours he was in class. His CS 1501 recitation, verbatim from his export.
+  const m = meeting({ dates: ["2026-09-02", "2026-09-03"] });
+  const w = window(m);
+  const intervals = parseIcs(
+    ics(
+      ...vevent(
+        "DTSTART;TZID=America/New_York:20260824T170000",
+        "DTEND;TZID=America/New_York:20260824T175000",
+        "RRULE:FREQ=WEEKLY;UNTIL=20261205T075959Z;INTERVAL=1;BYDAY=TH",
+        "SUMMARY:CS 1501",
+        "TRANSP:TRANSPARENT"
+      )
+    ),
+    w
+  );
+  const s = applyBusyIntervals(w.slots, intervals);
+  assert.equal(row(m, s, 0), "############", "Wed has no recitation");
+  assert.equal(row(m, s, 1), "##..########", "Thu 5:00-5:50 is taken");
 });
 
 test("events outside the window are ignored; ones crossing it are clipped", () => {


### PR DESCRIPTION
Reported by Jayson: uploaded his Pitt class schedule, and the import selected all 136 hours of the poll — while the banner cheerfully reported `3 busy blocks across 3 days (~3h)`.

His actual `.ics` explains it. **28 of its 100 events carry `TRANSP:TRANSPARENT`, and that includes every class:**

```
DTSTART;TZID=America/New_York:20260824T170000
RRULE:FREQ=WEEKLY;UNTIL=20261205T075959Z;INTERVAL=1;BYDAY=TH
SUMMARY:CS 1501
TRANSP:TRANSPARENT
```

That's the Thursday 5pm recitation he called out. Same for CS 1502, CS 1530, the Mon/Wed CS 1501 lecture, RUSS 0850, VIET 0100. Pitt's course feed ships them all marked Free.

`expandEvent` skipped them by design — *"Declined and free-marked events aren't conflicts."* That reads well for a squishy lunch and fails badly for a schedule that arrives pre-marked, because the result is someone who looks wide open on exactly the hours they are in class. It's the failure mode `AvailabilityGrid.js` opens by warning about:

> it fails silently in the dangerous direction … you look wide open, and the group books a time you can't make.

## Change

Transparency now only speaks for **all-day** events. Those really are labels — his file has `Acadia`, `SF`, `St Thomas`, `Last day of freshman year`, `dual midterms` — and treating one as a conflict would wipe the whole day. Timed events count as busy whatever the flag says.

```js
if (event.status === "CANCELLED") return;
if (event.transparent && event.start.allDay) return;
```

Over-claiming a conflict is the recoverable direction, and the banner already asks you to adjust anything that's off.

## Measured on his real export

| | banner | selected | Thu Sep 3 |
|---|---|---|---|
| before | 3 blocks / 3 days / ~3h | 136h of 136h | nothing |
| after | 30 blocks / 13 days / ~36h | 130.5h of 136h | **5pm, 5:30pm blocked** |

Wed Sep 2 also picks up 4pm, from the 3–4:15 lecture bleeding 15 minutes into the slot. Friday stays clear — his only Friday class is an 11am recitation, outside the grid.

## Tests

The old test asserted the behaviour being changed, so it's split into three that say what we now mean:

- a cancelled event is not a conflict
- an all-day event marked free is a label, not a conflict
- a timed event marked free still counts as busy — built from his CS 1501 recitation verbatim

79/79 pass, including the 16 API integration tests.

## Known gap, not addressed here

Uploading two `.ics` files back to back doesn't combine them — the second import replaces the first. Most people have their calendar split across two or three files, so this is worth fixing, but it's separate from this bug.