### PR TITLE
feat(meet): import several calendars at once

### DIFF
--- a/src/components/meet/ImportPanel.js
+++ b/src/components/meet/ImportPanel.js
@@ -1,6 +1,8 @@
 import React, { useRef, useState } from "react";
 import {
   applyBusyIntervals,
+  calendarName,
+  mergeIntervals,
   parseIcs,
   summarizeIntervals,
 } from "../../lib/meet/calendar";
@@ -14,40 +16,70 @@ const BUTTON =
  * selects every slot your calendar leaves open, so the common case is "import, fix one
  * thing, done".
  *
+ * Calendars are additive, and that is the whole point of keeping a list here rather
+ * than a single parsed result. Nobody's week lives in one file: Google exports one
+ * .ics per calendar, so a student's classes and their club meetings and their shifts
+ * arrive separately. An import that replaced the last one made two uploads look like
+ * a bug — the second silently undid the first — and left the person with a grid that
+ * hid whichever half they loaded first.
+ *
+ * Each source is listed by the calendar's own name, because the commonest failure is
+ * uploading the wrong file, and "School" vs "To do" on screen catches that instantly.
+ * Removing one re-derives the selection from whatever is left, so a wrong file is one
+ * click to undo rather than a page reload.
+ *
  * Google is asked for the `calendar.freebusy` scope and nothing else — that grant
  * returns opaque start/end pairs, so event titles, guests and locations never reach the
  * browser in the first place. Busy intervals become slot states here, on this machine,
  * and only one digit per half hour is ever sent to the server.
  */
 export default function ImportPanel({ slots, states, manual, onImport, windowMs }) {
+  const [sources, setSources] = useState([]);
   const [status, setStatus] = useState(null);
   const [busy, setBusy] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   const fileRef = useRef(null);
 
-  const ingest = (intervals, source, tz) => {
-    const next = applyBusyIntervals(slots, intervals, { previous: states, manual });
-    onImport(next, source);
+  /**
+   * Re-derive the whole selection from every loaded calendar at once. Always a fresh
+   * union rather than a patch on the last result, so adding and removing a file leave
+   * you exactly where you started.
+   */
+  const apply = (nextSources) => {
+    const intervals = mergeIntervals(nextSources.flatMap((s) => s.intervals));
+    onImport(
+      applyBusyIntervals(slots, intervals, { previous: states, manual }),
+      nextSources.some((s) => s.kind === "ics") ? "ics" : "google"
+    );
+    setSources(nextSources);
+
+    if (!nextSources.length) {
+      setStatus(null);
+      return;
+    }
+    const many = nextSources.length > 1;
     setStatus({
       kind: "ok",
       text: intervals.length
-        ? `Selected the times your calendar is open, around ${summarizeIntervals(
-            intervals,
-            tz
-          )}. Adjust anything that's off.`
-        : "Your calendar is clear for this whole window, so everything is selected.",
+        ? `Selected the times ${
+            many ? `those ${nextSources.length} calendars are` : "your calendar is"
+          } open, around ${summarizeIntervals(intervals, windowMs.tz)}. Adjust anything that's off.`
+        : `${many ? "Those calendars are" : "Your calendar is"} clear for this whole window, so everything is selected.`,
     });
   };
+
+  /** Later uploads of the same calendar replace it rather than double-counting it. */
+  const put = (list, entry) => [...list.filter((s) => s.id !== entry.id), entry];
 
   const runGoogle = async () => {
     setBusy(true);
     setStatus(null);
     try {
-      ingest(
-        await fetchGoogleBusy({ timeMinMs: windowMs.start, timeMaxMs: windowMs.end }),
-        "google",
-        windowMs.tz
-      );
+      const intervals = await fetchGoogleBusy({
+        timeMinMs: windowMs.start,
+        timeMaxMs: windowMs.end,
+      });
+      apply(put(sources, { id: "google", kind: "google", label: "Google Calendar", intervals }));
     } catch (err) {
       if (!err.cancelled) setStatus({ kind: "error", text: err.message });
     } finally {
@@ -55,20 +87,39 @@ export default function ImportPanel({ slots, states, manual, onImport, windowMs 
     }
   };
 
-  const readFile = async (file) => {
-    if (!file) return;
+  const readFiles = async (fileList) => {
+    const files = Array.from(fileList || []);
+    if (!files.length) return;
     setBusy(true);
     setStatus(null);
     try {
-      const text = await file.text();
-      if (!/BEGIN:VCALENDAR/i.test(text)) {
-        throw new Error("That doesn't look like a calendar export (.ics).");
+      let next = sources;
+      const rejected = [];
+      for (const file of files) {
+        const text = await file.text();
+        if (!/BEGIN:VCALENDAR/i.test(text)) {
+          rejected.push(file.name);
+          continue;
+        }
+        next = put(next, {
+          id: `ics:${file.name}`,
+          kind: "ics",
+          label: calendarName(text) || file.name.replace(/\.ics$/i, ""),
+          intervals: parseIcs(text, {
+            windowStartMs: windowMs.start,
+            windowEndMs: windowMs.end,
+          }),
+        });
       }
-      ingest(
-        parseIcs(text, { windowStartMs: windowMs.start, windowEndMs: windowMs.end }),
-        "ics",
-        windowMs.tz
-      );
+      if (next !== sources) apply(next);
+      if (rejected.length) {
+        setStatus({
+          kind: "error",
+          text: `${rejected.join(", ")} ${
+            rejected.length === 1 ? "doesn't" : "don't"
+          } look like a calendar export (.ics).`,
+        });
+      }
     } catch (err) {
       setStatus({ kind: "error", text: err.message });
     } finally {
@@ -89,17 +140,17 @@ export default function ImportPanel({ slots, states, manual, onImport, windowMs 
       onDrop={(e) => {
         e.preventDefault();
         setDragOver(false);
-        readFile(e.dataTransfer.files && e.dataTransfer.files[0]);
+        readFiles(e.dataTransfer.files);
       }}
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="min-w-0">
           <p className="font-bold">
-            {dragOver ? "Drop the .ics file" : "Import your calendar"}
+            {dragOver ? "Drop the .ics files" : "Import your calendar"}
           </p>
           <p className="text-gray-500 text-sm">
-            We&apos;ll select when you&apos;re free. Only free/busy is read — never
-            event details.
+            We&apos;ll select when you&apos;re free. Add as many calendars as you like
+            — only free/busy is read, never event details.
           </p>
         </div>
 
@@ -115,20 +166,42 @@ export default function ImportPanel({ slots, states, manual, onImport, windowMs 
             onClick={() => fileRef.current && fileRef.current.click()}
             disabled={busy}
           >
-            Upload .ics
+            {sources.some((s) => s.kind === "ics") ? "Add another .ics" : "Upload .ics"}
           </button>
           <input
             ref={fileRef}
             type="file"
             accept=".ics,text/calendar"
+            multiple
             className="meet-sr"
             onChange={(e) => {
-              readFile(e.target.files && e.target.files[0]);
+              readFiles(e.target.files);
               e.target.value = "";
             }}
           />
         </div>
       </div>
+
+      {sources.length > 0 && (
+        <ul className="mt-3 flex flex-wrap gap-2">
+          {sources.map((s) => (
+            <li
+              key={s.id}
+              className="flex items-center gap-2 px-3 py-1 text-sm border border-gray-200 rounded-full bg-gray-50"
+            >
+              <span className="font-semibold truncate max-w-[16rem]">{s.label}</span>
+              <button
+                type="button"
+                className="text-gray-400 hover:text-red-700"
+                aria-label={`Remove ${s.label}`}
+                onClick={() => apply(sources.filter((x) => x.id !== s.id))}
+              >
+                &times;
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
 
       {status && (
         <p

--- a/src/lib/meet/calendar.js
+++ b/src/lib/meet/calendar.js
@@ -135,6 +135,21 @@ export function parseIcs(text, { windowStartMs, windowEndMs }) {
   return mergeIntervals(intervals);
 }
 
+/**
+ * The calendar's own name, from the export header.
+ *
+ * Worth surfacing because the commonest import failure isn't a parse error, it's the
+ * wrong file: Google hands you one .ics per calendar with near-identical names, and a
+ * schedule that lives on a calendar you didn't upload looks exactly like a schedule
+ * that's empty. Naming what was read lets you catch that at a glance.
+ */
+export function calendarName(text) {
+  for (const line of unfold(String(text || ""))) {
+    if (/^X-WR-CALNAME:/i.test(line)) return line.slice(line.indexOf(":") + 1).trim().slice(0, 60);
+  }
+  return "";
+}
+
 /** RFC 5545 folds long lines with a leading space or tab on the continuation. */
 function unfold(text) {
   const out = [];

--- a/tests/meet/calendar.test.mjs
+++ b/tests/meet/calendar.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   applyBusyIntervals,
+  calendarName,
   mergeIntervals,
   parseIcs,
   trackManualEdits,
@@ -249,6 +250,39 @@ test("manual edits survive a re-import", () => {
   const next = applyBusyIntervals(w.slots, intervals, { previous, manual });
   assert.equal(next[0], UNAVAILABLE, "the hand edit is not overwritten by the import");
   assert.equal(next[1], AVAILABLE, "everything else is filled in from the calendar");
+});
+
+test("several calendars combine instead of replacing each other", () => {
+  // Nobody's week lives in one file — Google exports one .ics per calendar, so a
+  // student's classes and their club meetings arrive separately.
+  const m = meeting({ dates: ["2026-09-02"] });
+  const w = window(m);
+  const school = parseIcs(
+    ics(...vevent("DTSTART;TZID=America/New_York:20260902T160000", "DTEND;TZID=America/New_York:20260902T170000")),
+    w
+  );
+  const clubs = parseIcs(
+    ics(...vevent("DTSTART;TZID=America/New_York:20260902T200000", "DTEND;TZID=America/New_York:20260902T210000")),
+    w
+  );
+
+  assert.equal(row(m, applyBusyIntervals(w.slots, school), 0), "..##########", "one on its own");
+  assert.equal(row(m, applyBusyIntervals(w.slots, clubs), 0), "########..##", "the other on its own");
+
+  const both = mergeIntervals([...school, ...clubs]);
+  assert.equal(both.length, 2);
+  assert.equal(row(m, applyBusyIntervals(w.slots, both), 0), "..######..##", "both at once");
+});
+
+test("a calendar is labelled by its own name, folded or not", () => {
+  assert.equal(calendarName(ics("X-WR-CALNAME:School")), "School");
+  assert.equal(
+    calendarName(["BEGIN:VCALENDAR", "X-WR-CALNAME:jaysondang561@gmail", "\t.com", "END:VCALENDAR"].join("\r\n")),
+    "jaysondang561@gmail.com",
+    "unfolded like any other property"
+  );
+  assert.equal(calendarName(ics()), "", "absent header is not an error");
+  assert.equal(calendarName(""), "");
 });
 
 test("garbage input does not throw", () => {


### PR DESCRIPTION
Follow-up to #144. Nobody's week lives in one file — Google exports one `.ics` per calendar, so a student's classes, club meetings and shifts arrive separately. Jayson's are split across **School** and **To do**.

Uploading the second one silently threw away the first: each import rebuilt the selection from that file alone, so the grid hid whichever half you loaded first.

## Change

The panel keeps a list of loaded calendars and re-derives the whole selection from their **union** each time one is added or removed. Always a fresh union rather than a patch on the last result, so adding a file and removing it again leaves you exactly where you started. The file input takes `multiple`, and so does a drag-and-drop.

Each source is listed by the calendar's own name from `X-WR-CALNAME`. That does double duty — the commonest import failure isn't a parse error, it's the wrong file, and Google's exports are named almost identically. `School` and `To do` sitting on screen makes that obvious at a glance, and the `×` makes a wrong file one click to undo rather than a page reload.

Re-uploading the same calendar replaces it instead of double-counting.

## Verified with Jayson's real exports

Both files dropped in one go, on a 3-day / 4pm–midnight poll:

| state | chips | banner | selected |
|---|---|---|---|
| both loaded | `School ×` `To do ×` | those 2 calendars are open, ~6 blocks across 3 days (~13h) | 22.5h of 24h |
| removed School | `To do ×` | *your calendar* is open, 3 blocks across 2 days (~6h) | 24h of 24h |
| removed both | — | — | 24h of 24h |

The 1.5h blocked with both loaded is Wed 4pm (CS 1501 lecture bleeding 15 min into the slot) plus Thu 5:00–5:50 (the recitation). Removing School correctly gives back the whole grid, since **To do**'s events — gym at 7am, midday office hours — all fall outside a 4pm–midnight window. Singular/plural in the banner follows the count.

No new console errors; the ones present are pre-existing (`Seo` defaultProps, `frameborder` in `index.js`).

## Tests

- several calendars combine instead of replacing each other
- a calendar is labelled by its own name, folded or not

81/81 pass, including the 16 API integration tests.

Jayson's `.ics` files were used only to verify locally — nothing from them is in the repo or the tests.