### PR TITLE
fix(meet): a preset no longer discards the imported calendar

### DIFF
--- a/src/components/meet/AvailabilityGrid.js
+++ b/src/components/meet/AvailabilityGrid.js
@@ -4,6 +4,7 @@ import { AVAILABLE, IF_NEEDED, UNAVAILABLE } from "../../lib/meet/model";
 import { dayLabel, isoWeekday, rangeLabel, timeLabel } from "../../lib/meet/time";
 
 const STATE_WORD = { 0: "unavailable", 1: "if needed", 2: "available" };
+const EMPTY_BUSY = new Set();
 
 /**
  * The input surface: **drag to add the times you're free.**
@@ -27,7 +28,7 @@ const STATE_WORD = { 0: "unavailable", 1: "if needed", 2: "available" };
  * stylus. Cells set `touch-action: none` so a finger drag paints instead of scrolling;
  * the time gutter keeps `pan-y` so the page can still be scrolled.
  */
-export default function AvailabilityGrid({ view, states, onChange }) {
+export default function AvailabilityGrid({ view, states, onChange, calendarBusy }) {
   const [draft, setDraft] = useState(null);
   const [tool, setTool] = useState(AVAILABLE);
   const [anchor, setAnchor] = useState(null);
@@ -38,6 +39,8 @@ export default function AvailabilityGrid({ view, states, onChange }) {
   const bodyRef = useRef(null);
   const drag = useRef(null);
   const touched = useRef(new Set());
+
+  const busy = calendarBusy || EMPTY_BUSY;
 
   const shown = draft || states;
 
@@ -125,10 +128,25 @@ export default function AvailabilityGrid({ view, states, onChange }) {
     // you with everything and no way back except Clear, so the buttons couldn't be used
     // to compare options — which is the obvious thing to try. Replacing also matches
     // how the date presets on the create screen already behave.
+    //
+    // What it replaces is your *answer*, though, never the calendar underneath it.
+    // "Weekdays" means the weekday hours you can actually make, so an imported
+    // conflict stays out: a preset that reselected your classes made the calendar in
+    // the list above a lie, and re-uploading it was the only way back.
     const next = new Uint8Array(states.length);
-    for (const i of preset.slots) next[i] = AVAILABLE;
+    let picked = 0;
+    for (const i of preset.slots) {
+      if (busy.has(i)) continue;
+      next[i] = AVAILABLE;
+      picked += 1;
+    }
     commit(next, allSlots, { replacesAll: true });
-    setAnnouncement(`${preset.label} — ${preset.slots.length} half-hours selected`);
+    const skipped = preset.slots.length - picked;
+    setAnnouncement(
+      `${preset.label} — ${picked} half-hours selected${
+        skipped ? `, ${skipped} left out as busy on your calendar` : ""
+      }`
+    );
   };
 
   const clearAll = () => {

--- a/src/components/meet/ImportPanel.js
+++ b/src/components/meet/ImportPanel.js
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import {
   applyBusyIntervals,
+  busySlotIndices,
   calendarName,
   mergeIntervals,
   parseIcs,
@@ -49,7 +50,10 @@ export default function ImportPanel({ slots, states, manual, onImport, windowMs 
     const intervals = mergeIntervals(nextSources.flatMap((s) => s.intervals));
     onImport(
       applyBusyIntervals(slots, intervals, { previous: states, manual }),
-      nextSources.some((s) => s.kind === "ics") ? "ics" : "google"
+      nextSources.some((s) => s.kind === "ics") ? "ics" : "google",
+      // The presets need to keep honouring these calendars after this import, so the
+      // grid gets the calendar's own verdict and not just the merged result.
+      busySlotIndices(slots, intervals)
     );
     setSources(nextSources);
 

--- a/src/lib/meet/calendar.js
+++ b/src/lib/meet/calendar.js
@@ -47,6 +47,24 @@ export function applyBusyIntervals(slots, intervals, { previous, manual } = {}) 
 }
 
 /**
+ * Which slots the calendar itself rules out, independent of anything done by hand
+ * since.
+ *
+ * Presets need this. "Weekdays" means the weekday hours you can actually make, so it
+ * has to know what the calendar already took: without it, one tap reselected every
+ * class an import had just carved out, and the only way back was to remove the
+ * calendar and upload it again — while its name sat in the list claiming otherwise.
+ */
+export function busySlotIndices(slots, intervals) {
+  const verdict = applyBusyIntervals(slots, intervals);
+  const out = new Set();
+  for (let i = 0; i < verdict.length; i += 1) {
+    if (verdict[i] === UNAVAILABLE) out.add(i);
+  }
+  return out;
+}
+
+/**
  * Record which slots were edited by hand, for the "manual edits win" rule above.
  *
  * A preset or Clear rewrites the whole grid in one tap, so the edit covers every slot —

--- a/src/pages/meet/[code].js
+++ b/src/pages/meet/[code].js
@@ -40,6 +40,9 @@ import { trackManualEdits } from "../../lib/meet/calendar";
 import { describeWindow, nameList, summarizeDates } from "../../lib/meet/format";
 import { durationLabel, localTz, rangeLabel, tzCity } from "../../lib/meet/time";
 
+// Stable identity so an unimported grid doesn't rebuild its presets every render.
+const EMPTY_BUSY = new Set();
+
 const SAVE_DEBOUNCE_MS = 650;
 const POLL_MS = 15000;
 
@@ -73,6 +76,8 @@ export default function MeetRoom({ params, location }) {
   const saveTimer = useRef(null);
   const pendingSlots = useRef(null);
   const manualEdits = useRef(new Set());
+  // Slots the loaded calendars rule out, so a preset can keep honouring them.
+  const [calendarBusy, setCalendarBusy] = useState(EMPTY_BUSY);
   const lastPayload = useRef(null);
 
   const browserTz = useMemo(() => localTz(), []);
@@ -238,8 +243,9 @@ export default function MeetRoom({ params, location }) {
   );
 
   const onImport = useCallback(
-    (next, importSource) => {
+    (next, importSource, busy) => {
       setMySlots(next);
+      setCalendarBusy(busy || EMPTY_BUSY);
       setSource(importSource);
       pendingSlots.current = next;
       if (saveTimer.current) window.clearTimeout(saveTimer.current);
@@ -429,7 +435,12 @@ export default function MeetRoom({ params, location }) {
                 windowMs={windowMs}
               />
 
-              <AvailabilityGrid view={view} states={mySlots} onChange={onGridChange} />
+              <AvailabilityGrid
+                view={view}
+                states={mySlots}
+                onChange={onGridChange}
+                calendarBusy={calendarBusy}
+              />
 
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <p className="text-gray-400 text-sm">

--- a/tests/meet/calendar.test.mjs
+++ b/tests/meet/calendar.test.mjs
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 import {
   applyBusyIntervals,
+  busySlotIndices,
   calendarName,
   mergeIntervals,
   parseIcs,
@@ -283,6 +284,43 @@ test("a calendar is labelled by its own name, folded or not", () => {
   );
   assert.equal(calendarName(ics()), "", "absent header is not an error");
   assert.equal(calendarName(""), "");
+});
+
+test("a preset does not reselect what the calendar already ruled out", () => {
+  // Jayson's report: import, tap Weekdays, and every class came back selected — the
+  // calendar was still listed in the panel but no longer reflected in the grid, and
+  // removing and re-uploading it was the only way back.
+  const m = meeting({ dates: ["2026-09-02", "2026-09-05"] }); // a Wednesday and a Saturday
+  const w = window(m);
+  const intervals = parseIcs(
+    ics(
+      ...vevent(
+        "DTSTART;TZID=America/New_York:20260902T170000",
+        "DTEND;TZID=America/New_York:20260902T190000"
+      )
+    ),
+    w
+  );
+  const busy = busySlotIndices(w.slots, intervals);
+  assert.deepEqual([...busy], [2, 3, 4, 5], "5-7pm on the Wednesday, and nothing else");
+
+  // Exactly what applyPreset does with a preset's slot list.
+  const preset = w.slots.filter((s) => s.date === "2026-09-02").map((s) => s.index);
+  const next = new Uint8Array(w.slots.length);
+  for (const i of preset) if (!busy.has(i)) next[i] = AVAILABLE;
+
+  assert.equal(row(m, next, 0), "##....######", "the imported conflict stays out");
+  assert.equal(row(m, next, 1), "............", "and the untouched day is still empty");
+});
+
+test("with no calendar loaded a preset selects everything it covers", () => {
+  const m = meeting({ dates: ["2026-09-02"] });
+  const w = window(m);
+  const busy = busySlotIndices(w.slots, []);
+  assert.equal(busy.size, 0);
+  const next = new Uint8Array(w.slots.length);
+  for (const s of w.slots) if (!busy.has(s.index)) next[s.index] = AVAILABLE;
+  assert.equal(row(m, next, 0), "############");
 });
 
 test("garbage input does not throw", () => {


### PR DESCRIPTION
Reported by Jayson, straight after #145:

> these buttons overide the ics and i have to delete and reupload for them to show once more

Import a calendar, tap **Weekdays**, and every class comes back selected. The only way to get the conflicts back is to remove the calendar and upload it again — while its name sits in the panel directly above the grid, claiming it's applied.

## Root cause

`applyPreset` builds a fresh array and sets every slot the preset covers to `AVAILABLE`, with no knowledge of what the calendar took out. Replacing the whole grid is correct for an *answer* — that's #143's behaviour and deliberate — but the calendar underneath it isn't an answer.

Before #145 an import was a one-shot action, so this was merely surprising. Now that calendars are listed, persistent state, the panel makes a promise the grid was quietly breaking.

## Change

A preset selects only what the loaded calendars leave open. `busySlotIndices(slots, intervals)` gives the calendar's own verdict — taken before any hand edits are layered on — and the grid skips those slots when filling a preset.

- **Clear** still clears everything. That one is an explicit start-over.
- **Drags and the day/row toggles are untouched.** Deciding you can make a class after all is a legitimate thing to say by hand; a preset is the coarse "fill in the obvious" action, which is where the calendar should constrain.
- The screen-reader announcement now reports what was actually selected and what the calendar held back: `Weekdays — 45 half-hours selected, 3 left out as busy on your calendar`.

## Verified with Jayson's real exports

Both his calendars loaded on a 3-day / 4pm–midnight poll, then each preset tapped:

| tap | before | after |
|---|---|---|
| after import | 22.5h | 22.5h |
| **Anytime** | **24h** — calendar wiped | 22.5h |
| **Weekdays** | **24h** — calendar wiped | 22.5h |
| **Evenings** | 21h | 20h |

The chips still read `School` `To do` in both runs; pre-fix that was a lie. The 1.5h held back is Wed 4pm (lecture bleeding 15 min into the slot) plus Thu 5:00–5:50 (recitation). Evenings starts at 5pm so it only loses the recitation, hence 20h not 19.5h.

## Tests

- a preset does not reselect what the calendar already ruled out
- with no calendar loaded a preset selects everything it covers

83/83 pass, including the 16 API integration tests.

## Not addressed

Jayson also floated overlaying the calendar on the grid itself, and called it a nit himself. Worth considering separately — it would make the constraint visible rather than only audible.

His `.ics` files were used only to verify locally; nothing from them is in the repo or the tests.