### PR TITLE
feat(meet): show imported conflicts on the grid

### DIFF
--- a/src/components/meet/AvailabilityGrid.js
+++ b/src/components/meet/AvailabilityGrid.js
@@ -399,6 +399,7 @@ export default function AvailabilityGrid({ view, states, onChange, calendarBusy 
   const renderCell = ({ key, slotIndex, minute, label, shape }) => {
     const state = shown[slotIndex];
     const isActive = active === slotIndex || (active == null && slotIndex === 0);
+    const isBusy = busy.has(slotIndex);
 
     return (
       <button
@@ -407,11 +408,14 @@ export default function AvailabilityGrid({ view, states, onChange, calendarBusy 
         className="meet-cell"
         data-slot={slotIndex}
         data-state={state}
+        data-busy={isBusy}
         data-anchor={anchor === slotIndex}
         {...shape}
         tabIndex={isActive ? 0 : -1}
         aria-pressed={state !== UNAVAILABLE}
-        aria-label={`${label.dow} ${label.md} ${timeLabel(minute)} — ${STATE_WORD[state]}`}
+        aria-label={`${label.dow} ${label.md} ${timeLabel(minute)} — ${STATE_WORD[state]}${
+          isBusy ? ", busy on your calendar" : ""
+        }`}
         onFocus={() => setActive(slotIndex)}
       />
     );
@@ -513,6 +517,11 @@ export default function AvailabilityGrid({ view, states, onChange, calendarBusy 
         <span className="inline-flex items-center gap-2">
           <span className="meet-swatch" data-state="0" /> Can&apos;t make it
         </span>
+        {busy.size > 0 && (
+          <span className="inline-flex items-center gap-2">
+            <span className="meet-swatch" data-busy="true" /> Busy on your calendar
+          </span>
+        )}
         <span className="text-gray-400">
           Arrows move · Space toggles · Shift fills a block
         </span>

--- a/src/styles/components/_meet.scss
+++ b/src/styles/components/_meet.scss
@@ -190,6 +190,46 @@
   background-size: 6px 6px;
 }
 
+/* The calendar's own verdict, drawn *over* your answer rather than as one of its
+   states — it is information about the world, not something you said.
+
+   Hatched, never filled, for two reasons: a fill would read as a fourth answer, and
+   the mark has to stay legible on white, on the dotted "if needed" texture, and on the
+   solid navy of a selected cell. Drawn on ::after so it layers cleanly over whichever
+   background the state supplies instead of competing with it. The 45deg run is the
+   mirror of the void cells' 135deg, so "no such time" and "you're busy then" never
+   read as the same thing. */
+.meet-cell[data-busy="true"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(29, 39, 88, 0.3) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+/* Over the navy fill the hatch has to invert to stay visible. Seeing it there is the
+   point: it means you have deliberately said yes to an hour your calendar has a
+   conflict in, which is allowed but worth showing. */
+.meet-cell[data-state="2"][data-busy="true"]::after {
+  background: repeating-linear-gradient(
+    45deg,
+    rgba(255, 255, 255, 0.55) 0 2px,
+    transparent 2px 5px
+  );
+}
+
+.meet-swatch[data-busy="true"] {
+  background: #fff repeating-linear-gradient(
+      45deg,
+      rgba(29, 39, 88, 0.3) 0 2px,
+      transparent 2px 5px
+    );
+}
+
 /* 2 = free — the affirmative answer, so it gets the solid brand fill */
 .meet-cell[data-state="2"] {
   background-color: var(--meet-primary);


### PR DESCRIPTION
Jayson's own suggestion, after #143, #144, #145 and #146 — three of which were the calendar and the grid disagreeing with nothing on screen to say so:

> maybe some of the when are you free options can overlay on the schedule but thats evil nit

Until now an import was audible only: a sentence in the panel, an announcement to a screen reader, and a total in hours. Whether a given cell was empty because you left it empty or because a class sits in it was not answerable by looking.

## Change

Cells the loaded calendars rule out carry a diagonal hatch.

- **Hatched, not filled.** A fill would read as a fourth answer next to free / if-needed / can't-make-it, and the mark has to survive on white, on the dotted if-needed texture, *and* on the solid navy of a selected cell.
- Drawn on `::after`, so it layers over whichever background the state supplies rather than competing with it — `[data-state="1"]` already uses `background-image`.
- Runs at **45deg** against the void cells' 135deg, so "no such time" and "you're busy then" never read alike.
- **Over a selected cell it inverts to white** and stays visible. That's the point: it means you deliberately said yes to an hour your calendar has a conflict in. Allowed, and worth seeing.
- The legend gains a swatch **only while a calendar is loaded**, so a grid nobody imported into looks exactly as it did.
- Screen readers get the same fact in the cell label: `available, busy on your calendar`.

## Verified with Jayson's real exports

Both calendars loaded on a 3-day / 4pm–10pm poll:

| | result |
|---|---|
| cells marked | `Wed Sep 2 4:00 PM`, `Thu Sep 3 5:00 PM`, `Thu Sep 3 5:30 PM` |
| legend | `Busy on your calendar` present |
| hatch on white | `rgba(29, 39, 88, 0.3)` at 45deg |

Then hand-selecting the blocked Wed 4pm cell:

| | before keypress | after |
|---|---|---|
| state | `0` | `2` |
| `data-busy` | `true` | `true` |
| hatch | `rgba(29, 39, 88, 0.3)` | `rgba(255, 255, 255, 0.55)` — inverted, still visible |
| aria-label | `unavailable, busy on your calendar` | `available, busy on your calendar` |
| total | 16.5h | 17h |

And removing both calendars: 0 marked cells, legend swatch gone.

No new console errors. 83/83 tests pass — this change is presentational, so the coverage is in #146's `busySlotIndices` tests that produce the set being drawn.

His `.ics` files were used only to verify locally; nothing from them is in the repo or the tests.